### PR TITLE
Projectile fixes and ui readability changes

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -349,7 +349,6 @@ function generateTowerClass(data){
                 //'lead' the target by shooting at a point 0.6% ahead of where the enemy is currently.
                 var distance = Phaser.Math.Distance.Between(enemy.x,enemy.y,this.x, this.y)
                 if ((enemy.name === 'speedy' && distance > 75) || distance > 150){
-                    console.log('leading target!')
                     if (leadTarget.t + 0.006 <= 1) {
                         leadTarget.t += 0.006
                     }
@@ -1487,7 +1486,7 @@ var LevelScene = new Phaser.Class({
 
     create: function()
     {
-        gold = 2000;
+        gold = 200;
         life = 20;
 
         this.secondPath = false;


### PR DESCRIPTION
1) gun tower missing targets (increased lead and allows bullets to go further than the tower's range)
2) gun  tower shooting at 0,0. 
3) Missiles spinning on targets and at the end of the map. 
4) name changes from arrow->gun and bomb-> missile in the UI gutter. 
5) some UI readability issues including the main game info (hp, gold, towers, etc) 
6) and finally that weird clipping of the upgrade text.  That last one is really weird. It only happens occasionally?  I've done some research, it seems to be an occasional phaser issue :man-shrugging: (edited)
I changed the fontfamily to be in line with everything else and I cant seem to replicate the issue